### PR TITLE
Add setting for CronJob apiVersion to support batch/v1 and batch/v1beta1

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ To install the latest version of Deep Security Smart Check into the default Kube
      ##
      ## Default value: {must be provided by the installer}
      secretSeed: YOUR-SECRET-HERE
+
+   # Change to batch/v1 if you want to deploy the Deep Security Smart Check in
+   # Kubernetes v1.25+
+   kubernetes:
+     cronjob:
+       apiVersion: batch/v1 # Default: batch/v1beta1
    ```
 
 2. Use `helm` to install Deep Security Smart Check with your site-specific settings:

--- a/templates/tasks.yaml
+++ b/templates/tasks.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.tasks.scan.enabled }}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: scan

--- a/templates/tasks.yaml
+++ b/templates/tasks.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.tasks.scan.enabled }}
-apiVersion: batch/{{ .Values.tasks.scan.apiVersion }}
+apiVersion: {{ .Values.kubernetes.cronjob.apiVersion }}
 kind: CronJob
 metadata:
   name: scan

--- a/templates/tasks.yaml
+++ b/templates/tasks.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.tasks.scan.enabled }}
-apiVersion: batch/v1
+apiVersion: batch/{{ .Values.tasks.scan.apiVersion }}
 kind: CronJob
 metadata:
   name: scan

--- a/values.yaml
+++ b/values.yaml
@@ -594,7 +594,8 @@ images:
     digest: sha256:d824424ae99ca6c55b3dc5dc9dc29fb40de5bd102d307b6713b0b20912c2af81
   openscapScan:
     repository: openscap-scan
-    digest: sha256:5a84f853ccad667232f211ddb394365247e59ad2a5910ac2eecc2d5654318d1a
+    # digest value in docker.io
+    digest: sha256:7b99d755566e09483983a4a836c65e91336d6c00118deaa6e6d6aa74a94c0811
   openscapFeedConsumer:
     repository: openscap-feed-consumer
     digest: sha256:bf612fc891534dc5ae98c3407ee81e251357225b361f19ecadaab37bfef0a913

--- a/values.yaml
+++ b/values.yaml
@@ -729,6 +729,7 @@ tasks:
     ##
     ## Default value: true
     enabled: true
+    apiVersion: v1beta1
 
     ## schedule controls the schedule for the scheduled scan. It is a string in
     ## [cron](https://en.wikipedia.org/wiki/Cron) format.

--- a/values.yaml
+++ b/values.yaml
@@ -719,6 +719,14 @@ networkPolicy:
   ## Default value: []
   additionalOutboundPorts: []
 
+kubernetes:
+  cronjob:
+    # The apiVersion is kept at `batch/v1beta1` to ensure backwards compatibility to kubernetes versions before v1.21
+    # configure apiVersion `batch/v1` if you want to deploy the Deep Security Smart Check on kubernetes v1.25+
+    #
+    # Default value: batch/v1beta1
+    apiVersion: batch/v1beta1
+
 # Scheduled system tasks
 tasks:
   # The scan task will periodically trigger scans on views that have the `schedule`
@@ -729,7 +737,6 @@ tasks:
     ##
     ## Default value: true
     enabled: true
-    apiVersion: v1beta1
 
     ## schedule controls the schedule for the scheduled scan. It is a string in
     ## [cron](https://en.wikipedia.org/wiki/Cron) format.


### PR DESCRIPTION
Kubernetes removed the support for the deprecated `batch/v1beta1` api implementation of CronJobs in v1.25 and promoted CronJobs to `batch/v1` back in v1.21. Therefore we currently cannot deploy CronJobs in up to date Kubernetes Clusters.

API promotion to `batch/v1` since: [Kubernetes v1.21](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md#api-change-5)
Support cease notice: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25